### PR TITLE
Remove Synechococcus-like AUIDs from annoTab in WorkspaceStartup

### DIFF
--- a/WorkspaceStartup/scripts/make_nifH_ASV_database.R
+++ b/WorkspaceStartup/scripts/make_nifH_ASV_database.R
@@ -255,7 +255,7 @@ filt_taxa <- "Synechococcus"
 ## - remove these from the annotation table
 annotTab <- annotTab %>%
   remove_taxa_from_annoTab(
-    filter_text = filter_text,
+    filter_text = filt_taxa,
     filter_column = Genome879.id)
 
 

--- a/WorkspaceStartup/scripts/make_nifH_ASV_database.R
+++ b/WorkspaceStartup/scripts/make_nifH_ASV_database.R
@@ -256,7 +256,7 @@ filt_taxa <- "Synechococcus"
 annotTab <- annotTab %>%
   remove_taxa_from_annoTab(
     filter_text = filter_text,
-    filter_column = "Genome879.id")
+    filter_column = Genome879.id)
 
 
 # Filter abundance table and sequence file, removing unannotated ASVs


### PR DESCRIPTION
Adds a function to the WorkspaceStartup that identifies and removes
AUIDs annotated as Synechococcus based on Genomes879 db. There are only
two AUIDs total that have minimal impact to nifH ASV database or
analysis but should be removed.